### PR TITLE
Sideload large inserts (book snapshots) into BQ via a GCS bucket 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,20 @@ pip install -r requirements.txt
 ```
 
 # Setup google cloud account
-Add this to `~/.bashrc`. The [service account](https://cloud.google.com/iam/docs/service-accounts-create) should have "BigQuery Admin" access or similar.
+Add this to `~/.bashrc`. The [service account](https://cloud.google.com/iam/docs/service-accounts-create) should have "BigQuery Admin" and 
+"Storage Admin" permissions or similar.
 - `export GOOGLE_APPLICATION_CREDENTIALS="/home/ec2-user/full-node-client/service-account.json"`
+
+# Integration test
+
+After setting up, you can test the script's ability to create and insert into BigQuery --
+both directly and via GCS -- with:
+
+```
+python test_bigquery_gcs_insert.py
+```
+
+This will print error messages if your service account is improperly configured.
 
 # Running it
 ```

--- a/bigquery_gcs_insert.py
+++ b/bigquery_gcs_insert.py
@@ -1,0 +1,104 @@
+import json
+import logging
+import os
+import tempfile
+import time
+import uuid
+from datetime import datetime
+from typing import List
+
+import google.cloud.exceptions
+from google.cloud import storage, bigquery
+
+
+def get_or_create_bucket(
+        client: storage.Client, name: str, location: str
+) -> storage.Bucket:
+    """Get or create a GCS bucket."""
+    bucket = client.bucket(name)
+
+    try:
+        bucket = client.get_bucket(bucket)
+        logging.info(f"Using existing GCS bucket: {name}")
+        return bucket
+    except google.cloud.exceptions.NotFound:
+        try:
+            bucket = client.create_bucket(bucket, location=location)
+            logging.info(f"Created GCS bucket: {name}")
+            return bucket
+        except Exception as e:
+            logging.error(f"Error creating GCS bucket: {e}")
+            raise
+
+
+def insert_via_gcs(
+        client: bigquery.Client,
+        bucket: storage.Bucket,
+        tbl: bigquery.Table,
+        rows: List[dict]
+) -> None:
+    """
+    Insert a series of `rows` to the given BQ `tbl` via the GCS `bucket`.
+
+    This is useful when the rows are too large to insert directly into BigQuery,
+    but note that there is still a file size limit (15TB) and row size limit
+    (100MB), per [1].
+
+    [1] https://cloud.google.com/bigquery/quotas#load_jobs
+
+    NOTE: Any JSON fields must be in Python dict form, not serialized strings.
+
+    Mechanically, this function
+     - Writes the rows to a JSON temp file
+     - Uploads the temp file to GCS
+     - Deletes the local copy
+     - Creates a load job to insert the GCS file into the table
+     - Waits for the job to complete
+    """
+    try:
+        # Generate a unique blob name for the payload
+        blob_name = f"{datetime.utcnow().isoformat()}_{uuid.uuid4()}.json"
+        blob_name = blob_name.replace(":", "-")
+
+        # Create a temporary file for the JSON payload
+        with tempfile.NamedTemporaryFile(delete=True, mode="w") as temp_file:
+            for row in rows:
+                json.dump(row, temp_file)
+                temp_file.write("\n")
+            temp_file.flush()
+
+            file_mb = os.path.getsize(temp_file.name) / (1024 * 1024)
+            logging.info(f"Wrote {file_mb}MB to temp file {temp_file.name}")
+
+            # Upload the file to GCS
+            blob = bucket.blob(blob_name)
+            blob.upload_from_filename(temp_file.name)
+            logging.info(f"Uploaded file to GCS: {blob.name}")
+
+        # Configure the BigQuery load job
+        job_config = bigquery.LoadJobConfig(
+            schema=tbl.schema,
+            source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
+            time_partitioning=tbl.time_partitioning,
+            clustering_fields=tbl.clustering_fields,
+        )
+
+        # Load data from GCS into BigQuery
+        logging.info(f"Loading data from GCS to BigQuery: {tbl}")
+        load_job = client.load_table_from_uri(
+            f"gs://{bucket.name}/{blob_name}", tbl, job_config=job_config
+        )
+
+        # Wait for the job to complete
+        n = 10
+        for _ in range(n):
+            result = load_job.result()
+            logging.info(f"Got job {result} with statue {result.state}")
+            if result.state == "DONE":
+                return
+            time.sleep(5)
+        logging.error(f"Job did not succeed within {n} iterations")
+
+    except Exception as e:
+        logging.error(f"Error during GCS-based insertion: {e}")
+        raise

--- a/bigquery_gcs_insert.py
+++ b/bigquery_gcs_insert.py
@@ -35,6 +35,17 @@ def get_or_create_bucket(
             raise e
 
 
+def set_lifecycle_policy(bucket: storage.Bucket, days: int) -> None:
+    """
+    Sets a lifecycle policy to delete objects in the bucket after a given
+    number of days.
+    """
+    bucket.add_lifecycle_delete_rule(age=days)
+    bucket.patch()
+    logging.info(f"Set lifecycle rule to delete objects after {days} "
+                 f"days in bucket {bucket.name}")
+
+
 def insert_via_gcs(
         client: bigquery.Client,
         bucket: storage.Bucket,
@@ -105,4 +116,4 @@ def insert_via_gcs(
 
     except Exception as e:
         logging.error(f"Error during GCS-based insertion: {e}")
-        raise
+        raise e

--- a/bq_helpers.py
+++ b/bq_helpers.py
@@ -122,6 +122,9 @@ class GCSWriter:
             storage.Client(), bucket_name, location
         )
 
+        # Keep bucket data for 1 day
+        gcs_insert.set_lifecycle_policy(self.bucket, 1)
+
         # Default middleware function does not modify data before insert
         self.middleware_fn = lambda x: x
 

--- a/bq_helpers.py
+++ b/bq_helpers.py
@@ -9,8 +9,8 @@ from google.cloud.exceptions import NotFound
 
 import bigquery_gcs_insert as gcs_insert
 
-# Schema and partitioning
-SCHEMA = [
+# Schema and partitioning used across all order types
+PLACE_ORDER_SCHEMA = [
     SchemaField("sent_at", "TIMESTAMP", mode="REQUIRED"),
     SchemaField("uuid", "STRING", mode="REQUIRED"),
     SchemaField("validator_address", "STRING", mode="REQUIRED"),
@@ -20,8 +20,8 @@ SCHEMA = [
     SchemaField("good_til_block", "INT64", mode="REQUIRED"),
     SchemaField("client_id", "INT64", mode="REQUIRED"),
 ]
-TIME_PARTITIONING = bigquery.TimePartitioning(field="sent_at")
-CLUSTERING_FIELDS = ["validator_address"]
+PLACE_ORDER_TIME_PARTITIONING = bigquery.TimePartitioning(field="sent_at")
+PLACE_ORDER_CLUSTERING_FIELDS = ["validator_address"]
 
 
 def create_table(

--- a/listen_to_grpc_stream.py
+++ b/listen_to_grpc_stream.py
@@ -107,7 +107,7 @@ async def listen_to_stream_and_write_to_bq(
                 row = process_message(response, server_address)
 
                 # If the row is too large, sideload into BQ via GCS
-                too_large_for_direct_insert = len(row['response']) > 1_000_000
+                too_large_for_direct_insert = len(row['response']) > 5_000_000
                 if too_large_for_direct_insert:
                     await gcs_writer.enqueue_data(row)
                 else:

--- a/place_orders.py
+++ b/place_orders.py
@@ -23,9 +23,9 @@ from v4_client_py.clients.helpers.chain_helpers import (
 from bq_helpers import (
     create_table,
     BatchWriter,
-    CLUSTERING_FIELDS,
-    SCHEMA,
-    TIME_PARTITIONING,
+    PLACE_ORDER_CLUSTERING_FIELDS,
+    PLACE_ORDER_SCHEMA,
+    PLACE_ORDER_TIME_PARTITIONING,
 )
 from client_helpers import (
     get_markets_data,
@@ -181,5 +181,5 @@ if __name__ == "__main__":
         format="%(asctime)s - %(levelname)s - %(message)s",
     )
 
-    create_table(DATASET_ID, TABLE_ID, SCHEMA, TIME_PARTITIONING, CLUSTERING_FIELDS)
+    create_table(DATASET_ID, TABLE_ID, PLACE_ORDER_SCHEMA, PLACE_ORDER_TIME_PARTITIONING, PLACE_ORDER_CLUSTERING_FIELDS)
     asyncio.run(main())

--- a/place_replacement_orders.py
+++ b/place_replacement_orders.py
@@ -23,9 +23,9 @@ from v4_client_py.clients.helpers.chain_helpers import (
 from bq_helpers import (
     create_table,
     BatchWriter,
-    CLUSTERING_FIELDS,
-    SCHEMA,
-    TIME_PARTITIONING,
+    PLACE_ORDER_CLUSTERING_FIELDS,
+    PLACE_ORDER_SCHEMA,
+    PLACE_ORDER_TIME_PARTITIONING,
 )
 from client_helpers import (
     get_markets_data,
@@ -182,5 +182,5 @@ if __name__ == "__main__":
         format="%(asctime)s - %(levelname)s - %(message)s",
     )
 
-    create_table(DATASET_ID, TABLE_ID, SCHEMA, TIME_PARTITIONING, CLUSTERING_FIELDS)
+    create_table(DATASET_ID, TABLE_ID, PLACE_ORDER_SCHEMA, PLACE_ORDER_TIME_PARTITIONING, PLACE_ORDER_CLUSTERING_FIELDS)
     asyncio.run(main())

--- a/place_stateful_orders.py
+++ b/place_stateful_orders.py
@@ -111,6 +111,8 @@ async def listen_to_block_stream_and_place_orders(batch_writer):
 
     logging.info("Finished placing orders")
 
+    logging.info("Finished placing orders")
+
 
 
 async def main():

--- a/place_stateful_orders.py
+++ b/place_stateful_orders.py
@@ -22,9 +22,9 @@ from v4_client_py.clients.helpers.chain_helpers import (
 from bq_helpers import (
     create_table,
     BatchWriter,
-    CLUSTERING_FIELDS,
-    SCHEMA,
-    TIME_PARTITIONING,
+    PLACE_ORDER_CLUSTERING_FIELDS,
+    PLACE_ORDER_SCHEMA,
+    PLACE_ORDER_TIME_PARTITIONING,
 )
 from client_helpers import (
     get_markets_data,
@@ -135,5 +135,5 @@ if __name__ == "__main__":
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s",
     )
-    create_table(DATASET_ID, TABLE_ID, SCHEMA, TIME_PARTITIONING, CLUSTERING_FIELDS)
+    create_table(DATASET_ID, TABLE_ID, PLACE_ORDER_SCHEMA, PLACE_ORDER_TIME_PARTITIONING, PLACE_ORDER_CLUSTERING_FIELDS)
     asyncio.run(main())

--- a/place_taker_orders.py
+++ b/place_taker_orders.py
@@ -18,9 +18,9 @@ from v4_client_py.clients.helpers.chain_helpers import (
 from bq_helpers import (
     create_table,
     BatchWriter,
-    CLUSTERING_FIELDS,
-    SCHEMA,
-    TIME_PARTITIONING,
+    PLACE_ORDER_CLUSTERING_FIELDS,
+    PLACE_ORDER_SCHEMA,
+    PLACE_ORDER_TIME_PARTITIONING,
 )
 from client_helpers import (
     get_markets_data,
@@ -178,5 +178,5 @@ if __name__ == "__main__":
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s",
     )
-    create_table(DATASET_ID, TABLE_ID, SCHEMA, TIME_PARTITIONING, CLUSTERING_FIELDS)
+    create_table(DATASET_ID, TABLE_ID, PLACE_ORDER_SCHEMA, PLACE_ORDER_TIME_PARTITIONING, PLACE_ORDER_CLUSTERING_FIELDS)
     asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 google-cloud-bigquery==3.19.0
-grpcio==1.66.0
+google-cloud-storage==2.18.2
 requests~=2.32.2
 v4-client-py==4.0.0
 v4-proto==5.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 google-cloud-bigquery==3.19.0
 google-cloud-storage==2.18.2
+grpcio==1.66.0
 requests~=2.32.2
 v4-client-py==4.0.0
 v4-proto==5.2.2

--- a/test_bigquery_gcs_insert.py
+++ b/test_bigquery_gcs_insert.py
@@ -125,6 +125,9 @@ def run_integration_test():
         time.sleep(2)
 
         try:
+            # Try creating the bucket again to test the 'get' in get_or_create
+            _ = get_or_create_bucket(storage.Client(), bucket.name, "EU")
+
             # Insert directly into BigQuery
             errors = client.insert_rows_json(tbl, [test_row_data])
             if errors:

--- a/test_bigquery_gcs_insert.py
+++ b/test_bigquery_gcs_insert.py
@@ -128,6 +128,9 @@ def run_integration_test():
             # Try creating the bucket again to test the 'get' in get_or_create
             _ = get_or_create_bucket(storage.Client(), bucket.name, "EU")
 
+            # Just test that this API call executes
+            set_lifecycle_policy(bucket, 1)
+
             # Insert directly into BigQuery
             errors = client.insert_rows_json(tbl, [test_row_data])
             if errors:

--- a/test_bigquery_gcs_insert.py
+++ b/test_bigquery_gcs_insert.py
@@ -1,0 +1,159 @@
+"""
+This script tests the `insert_via_gcs` function from `bigquery_gcs_insert.py`,
+which inserts rows into BigQuery via Google Cloud Storage.
+
+It creates a new GCS bucket and BigQuery table, inserts two rows into the table,
+one directly and one via GCS, and then validates the results before deleting
+the resources.
+"""
+from typing import Tuple
+
+from bigquery_gcs_insert import *
+
+
+def create_test_resources(
+        client: bigquery.Client,
+        schema: list[bigquery.SchemaField],
+        time_partitioning: bigquery.TimePartitioning,
+        clustering_fields: list[str],
+) -> Tuple[storage.Bucket, bigquery.Table]:
+    """Create a new GCS bucket and a BigQuery table for testing."""
+    try:
+        # Generate unique names for the table and bucket
+        bucket_name = f"test-bucket-{uuid.uuid4()}"
+        project_id = client.project
+        dataset_id = "integration_test_dataset"
+        table_name = f"test_table_{uuid.uuid4().hex}"
+        table_id = f"{project_id}.{dataset_id}.{table_name}"
+
+        # Create BigQuery dataset if it doesn't exist
+        logging.info(f"Creating BQ table project_id: {project_id} "
+                     f"dataset_id: {dataset_id} table_id: {table_id}")
+        dataset_ref = bigquery.Dataset(f"{project_id}.{dataset_id}")
+        client.create_dataset(dataset_ref, exists_ok=True)
+        logging.info(f"Created or verified dataset: {dataset_id}")
+
+        # Create BigQuery table
+        tbl = bigquery.Table(table_id, schema=schema)
+        tbl.time_partitioning = time_partitioning
+        tbl.clustering_fields = clustering_fields
+        tbl = client.create_table(tbl)
+        logging.info(f"Created BigQuery table: {table_id}")
+
+        bucket = get_or_create_bucket(storage.Client(), bucket_name, "EU")
+        return bucket, tbl
+
+    except Exception as e:
+        logging.error(f"Error during setup: {e}")
+        raise
+
+
+def cleanup_test_resources(client: bigquery.Client, tbl: bigquery.Table, bucket: storage.Bucket):
+    """Delete the BigQuery table and GCS bucket."""
+    try:
+        # Delete the BigQuery table
+        client.delete_table(tbl, not_found_ok=True)
+        logging.info(f"Deleted BigQuery table: {tbl}")
+
+        # Delete the GCS bucket and its contents
+        bucket.delete(force=True)
+        logging.info(f"Deleted GCS bucket: {bucket.name}")
+
+        logging.info("Cleanup completed successfully.")
+
+    except Exception as e:
+        logging.error(f"Error during cleanup: {e}")
+        raise
+
+
+def validate_results(client: bigquery.Client, tbl: bigquery.Table) -> None:
+    """Validate that the two inserted rows exist and are identical except for the UUID."""
+    try:
+        query = f"SELECT * FROM `{tbl}` ORDER BY uuid"
+        logging.info(f"Running query: {query}")
+        query_job = client.query(query)
+        rows = list(query_job.result())
+        logging.info(f"Query results: {rows}")
+
+        # Print as JSON
+        for idx, row in enumerate(rows):
+            for k in row.keys():
+                logging.info(f"row={idx} k={k} type={type(row[k])} v={row[k]}")
+
+        # Ensure there are two rows
+        assert len(rows) == 2, "There should be exactly two rows in the table"
+
+        # Validate the UUIDs
+        assert rows[0].uuid == "bar", "First row UUID should be 'bar'"
+        assert rows[1].uuid == "bar_modified", "Second row UUID should be 'bar_modified'"
+
+        # Validate other fields are identical
+        for field in ["received_at", "server_address", "response"]:
+            assert rows[0][field] == rows[1][field], f"{field} field does not match"
+
+        logging.info("Validation successful: rows identical except for UUID.")
+    except Exception as e:
+        logging.error(f"Error during validation: {e}")
+        raise
+
+
+def run_integration_test():
+    """Run the full integration test."""
+    # Dataset configuration
+    schema = [
+        bigquery.SchemaField("received_at", "TIMESTAMP", mode="REQUIRED"),
+        bigquery.SchemaField("server_address", "STRING", mode="REQUIRED"),
+        bigquery.SchemaField("uuid", "STRING", mode="REQUIRED"),
+        bigquery.SchemaField("response", "JSON", mode="NULLABLE"),
+    ]
+    tp = bigquery.TimePartitioning(field="received_at")
+    clustering = ["server_address"]
+
+    test_row_data = {
+        "received_at": datetime.utcnow().isoformat("T") + "Z",
+        "server_address": "foo",
+        "uuid": "bar",
+        "response": '{"updates": [{"foo": "short JSON string"}, {"bar": "long JSON string"}]}',
+    }
+
+    try:
+        # Setup temporary cloud resources for testing
+        client = bigquery.Client()
+        bucket, tbl = create_test_resources(client, schema, tp, clustering)
+
+        # Give them time to init (empirically determined)
+        time.sleep(2)
+
+        try:
+            # Insert directly into BigQuery
+            errors = client.insert_rows_json(tbl, [test_row_data])
+            if errors:
+                logging.error(f"Failed to insert row directly: {errors}")
+
+            # Modify the payload and insert via GCS
+            modified_row = test_row_data.copy()
+            modified_row['uuid'] = 'bar_modified'
+            modified_row['response'] = json.loads(modified_row['response'])
+            insert_via_gcs(client, bucket, tbl, [modified_row])
+
+            # Validate the results
+            validate_results(client, tbl)
+
+        except Exception as e:
+            logging.error(f"Integration test failed: {e}")
+        finally:
+            # Cleanup resources
+            cleanup_test_resources(client, tbl, bucket)
+            pass
+    except Exception as e:
+        logging.error(f"Error during setup: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info(
+        f"GOOGLE_APPLICATION_CREDENTIALS="
+        f"{os.environ['GOOGLE_APPLICATION_CREDENTIALS']}"
+    )
+    run_integration_test()


### PR DESCRIPTION
Adds utils to do what the title says, plus an integration test to make sure it works (creates a temp bucket and table, inserts, verifies, then destroys them). 