### PR TITLE
Maintenance and bugfixes

### DIFF
--- a/bq_helpers.py
+++ b/bq_helpers.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime
 from typing import List, Callable
 
+from google.api_core.exceptions import GoogleAPICallError
 from google.cloud import bigquery, storage
 from google.cloud.bigquery import SchemaField
 from google.cloud.exceptions import NotFound
@@ -67,8 +68,11 @@ class BatchWriter:
             )
             if errors:
                 logging.error(f"Errors occurred: {errors}")
+        # TODO: Catch batch too large thing and fall back to GCS writer
+        except GoogleAPICallError as e:
+            logging.error(f"Error inserting {len(data_buffer)} rows (code = {e.code}): {e}")
         except Exception as e:
-            logging.error(f"Error inserting rows: {e}")
+            logging.error(f"Error inserting {len(data_buffer)} rows: {e}")
         finally:
             self.last_flush_time = datetime.utcnow()
 

--- a/client_helpers.py
+++ b/client_helpers.py
@@ -62,19 +62,20 @@ def place_order(client, block, msg_and_order, batch_writer):
 
 
 def precompute_order(
-    client,
-    ledger_client,
-    market,
-    subaccount,
-    side,
-    price,
-    client_id,
-    good_til_block,
-    good_til_block_time,
-    size,
-    order_flags,
-    time_in_force,
-    sequence_number,
+        client,
+        ledger_client,
+        market,
+        subaccount,
+        side,
+        price,
+        client_id,
+        good_til_block,
+        good_til_block_time,
+        size,
+        order_flags,
+        time_in_force,
+        sequence_number,
+        account_number,
 ):
     # precompute order and sign the order
     clob_pair_id = market["clobPairId"]
@@ -114,7 +115,6 @@ def precompute_order(
     memo = None
 
     fee = ledger_client.estimate_fee_from_gas(gas_limit)
-    account = ledger_client.query_account(sender.address())
 
     tx.seal(
         SigningCfg.direct(sender.public_key(), sequence_number),
@@ -122,9 +122,13 @@ def precompute_order(
         gas_limit=gas_limit,
         memo=memo,
     )
-    tx.sign(sender.signer(), ledger_client.network_config.chain_id, account.number)
+    tx.sign(
+        sender.signer(),
+        ledger_client.network_config.chain_id,
+        account_number
+    )
     tx.complete()
-    return (tx, msg)
+    return tx, msg
 
 
 async def place_orders(client, block, msg_and_orders, batch_writer):

--- a/client_helpers.py
+++ b/client_helpers.py
@@ -43,6 +43,16 @@ def setup_clients(grpc_endpoint):
     return client, ledger_client
 
 
+def get_current_block_with_retries(client: CompositeClient):
+    for i in range(5):
+        try:
+            return client.get_current_block()
+        except Exception as error:
+            if i == 4:
+                raise error
+    raise Exception("Failed to get current block")
+
+
 def get_markets_data(client, market):
     markets_response = client.indexer_client.markets.get_perpetual_markets(market)
     return markets_response.data["markets"][market]

--- a/listen_to_grpc_stream.py
+++ b/listen_to_grpc_stream.py
@@ -22,7 +22,7 @@ from bq_helpers import create_table, BatchWriter, GCSWriter
 # Dataset configuration
 DATASET_ID = "full_node_stream"
 TABLE_ID = "responses"
-CLOB_PAIR_IDS = range(144)  # TODO: Make this automatic
+CLOB_PAIR_IDS = range(1000)  # Have to update if too many more pairs are added
 
 # If data to too large for direct insert, use this GCS bucket to sideload
 GCS_BUCKET = "full_node_stream_sideload"

--- a/listen_to_grpc_stream.py
+++ b/listen_to_grpc_stream.py
@@ -91,12 +91,14 @@ def process_error(error_msg, server_address):
     return data
 
 
-# TODO: Log message counts every 10 mins
 async def listen_to_stream_and_write_to_bq(
         channel, batch_writer, gcs_writer, server_address
 ):
     retry_count = 0
     start_time = datetime.utcnow()
+
+    msg_count = 0
+    msg_count_time = datetime.utcnow()
 
     while retry_count < MAX_RETRIES_PER_DAY:
         try:
@@ -108,12 +110,18 @@ async def listen_to_stream_and_write_to_bq(
                 row = process_message(response, server_address)
 
                 # If the row is too large, sideload into BQ via GCS
-                # TODO: Make this automatic based on error when doing normal insert
-                too_large_for_direct_insert = len(row['response']) > 5_000_000
+                too_large_for_direct_insert = len(row['response']) > 1_000_000
                 if too_large_for_direct_insert:
-                    await gcs_writer.enqueue_data(row)
+                    await gcs_writer.enqueue_data([row])
                 else:
                     await batch_writer.enqueue_data(row)
+
+                # Log message counts every 15 mins
+                msg_count += 1
+                if datetime.utcnow() - msg_count_time > timedelta(minutes=15):
+                    logging.info(f"Saw {msg_count} msgs in the last 15 minutes")
+                    msg_count_time = datetime.utcnow()
+                    msg_count = 0
 
             await batch_writer.enqueue_data(
                 process_error("Stream ended", server_address)
@@ -168,16 +176,22 @@ def preprocess_row_for_gcs(row: dict) -> dict:
 
 
 async def main(server_address):
+    # Writer for exceptionally large rows (book snapshots)
+    gcs_writer = GCSWriter(DATASET_ID, TABLE_ID, SCHEMA, GCS_BUCKET)
+    gcs_writer.set_middleware(preprocess_row_for_gcs)
+    gcs_writer_task = asyncio.create_task(gcs_writer.gcs_writer_loop())
+
     # Writer for direct BigQuery inserts
     batch_writer = BatchWriter(
         DATASET_ID, TABLE_ID, WORKER_COUNT, BATCH_SIZE, BATCH_TIMEOUT
     )
     batch_writer_task = asyncio.create_task(batch_writer.batch_writer_loop())
 
-    # Writer for exceptionally large rows (book snapshots)
-    gcs_writer = GCSWriter(DATASET_ID, TABLE_ID, SCHEMA, GCS_BUCKET)
-    gcs_writer.set_middleware(preprocess_row_for_gcs)
-    gcs_writer_task = asyncio.create_task(gcs_writer.gcs_writer_loop())
+    # If the direct writer encounters a 413 error, fall back to sideloading
+    async def error_413_handler(data_buffer, e):
+        logging.error(f"Error 413 occurred, sideloading {len(data_buffer)} rows.")
+        await gcs_writer.enqueue_data(data_buffer)
+    batch_writer.set_error_413_handler(error_413_handler)
 
     # Adjust to use secure channel if needed
     logging.info(f"Connecting to server at {server_address}...")

--- a/place_orders.py
+++ b/place_orders.py
@@ -111,6 +111,7 @@ def pre_signing_thread(client, ledger_client, market, subaccount, orders, lock):
         time.sleep(0.2)
 
 
+# TODO: Simplify
 async def listen_to_block_stream_and_place_orders(batch_writer):
     # Setup clients to broadcast
     wallet = LocalWallet.from_mnemonic(DYDX_MNEMONIC, BECH32_PREFIX)

--- a/place_orders.py
+++ b/place_orders.py
@@ -86,6 +86,7 @@ def pre_signing_thread(client, ledger_client, market, subaccount, orders, lock):
                             ORDER_FLAGS_SHORT_TERM,
                             TIME_IN_FORCE,
                             account.sequence,
+                            account.number,
                         )
                     )
                     orders[current_block].append(
@@ -103,6 +104,7 @@ def pre_signing_thread(client, ledger_client, market, subaccount, orders, lock):
                             ORDER_FLAGS_SHORT_TERM,
                             TIME_IN_FORCE,
                             account.sequence,
+                            account.number,
                         )
                     )
                     client_id += NUM_ORDERS_PER_SIDE_EACH_BLOCK * 2
@@ -111,7 +113,7 @@ def pre_signing_thread(client, ledger_client, market, subaccount, orders, lock):
         time.sleep(0.2)
 
 
-# TODO: Simplify
+# TODO: Simplify + catch client errors
 async def listen_to_block_stream_and_place_orders(batch_writer):
     # Setup clients to broadcast
     wallet = LocalWallet.from_mnemonic(DYDX_MNEMONIC, BECH32_PREFIX)
@@ -132,7 +134,7 @@ async def listen_to_block_stream_and_place_orders(batch_writer):
     num_blocks_placed = 0
     time.sleep(5)
     while num_blocks_placed < NUM_BLOCKS:
-        current_block = client.get_current_block()
+        current_block = client.get_current_block()  # TODO: this can fail
         if previous_block < current_block:
             logging.info(f"New block: {current_block}")
 

--- a/place_replacement_orders.py
+++ b/place_replacement_orders.py
@@ -89,6 +89,7 @@ def pre_signing_thread(client, ledger_client, market, subaccount, orders, lock):
                             ORDER_FLAGS_SHORT_TERM,
                             TIME_IN_FORCE,
                             account.sequence,
+                            account.number,
                         )
                     )
                     orders[current_block].append(
@@ -106,6 +107,7 @@ def pre_signing_thread(client, ledger_client, market, subaccount, orders, lock):
                             ORDER_FLAGS_SHORT_TERM,
                             TIME_IN_FORCE,
                             account.sequence,
+                            account.number,
                         )
                     )
                 current_block += 1

--- a/place_stateful_orders.py
+++ b/place_stateful_orders.py
@@ -41,7 +41,7 @@ DATASET_ID = "latency_experiments"
 TABLE_ID = "long_running_stateful_orders"
 
 # Batch settings for BQ writes
-BATCH_SIZE = 2
+BATCH_SIZE = 1  # write every order to BQ as soon as it is placed
 BATCH_TIMEOUT = 10
 WORKER_COUNT = 1
 
@@ -53,9 +53,7 @@ BUY_PRICE = 0.01
 SELL_PRICE = 10
 SIZE = 1
 MARKET = "AXL-USD"
-NUM_BLOCKS = 1000
-WAIT_BLOCKS = 10
-MAX_LEN_ORDERS = 20000
+NUM_BLOCKS = 10_000
 DYDX_MNEMONIC = config["stateful_mnemonic"]
 GTBT_DELTA = 5
 PLACE_INTERVAL = 10
@@ -66,53 +64,55 @@ async def listen_to_block_stream_and_place_orders(batch_writer):
     wallet = LocalWallet.from_mnemonic(DYDX_MNEMONIC, BECH32_PREFIX)
     client, ledger_client = setup_clients(config["full_node_submission_address"])
 
+    market = await asyncio.to_thread(get_markets_data, client, MARKET)
     subaccount = Subaccount(wallet, 0)
-    market = get_markets_data(client, MARKET)
+    account = await asyncio.to_thread(
+        ledger_client.query_account,
+        subaccount.wallet.address()
+    )
+
     client_id = randrange(0, 2**32 - 1)
     num_blocks_placed = 0
+    sequence = account.sequence
     while num_blocks_placed < NUM_BLOCKS:
-        logging.info(f"Presigning orders {num_blocks_placed}")
-        account = ledger_client.query_account(subaccount.wallet.address())
         # only place one order each time, due to Stateful order rate limit
-        orders = [
-            precompute_order(
-                client,
-                ledger_client,
-                market,
-                subaccount,
-                OrderSide.BUY,
-                BUY_PRICE,
-                client_id,
-                0,
-                client.calculate_good_til_block_time(GTBT_DELTA),
-                SIZE,
-                ORDER_FLAGS_LONG_TERM,
-                TIME_IN_FORCE,
-                account.sequence,
-            )
-        ]
+        logging.info(f"Presigning orders {num_blocks_placed}")
+        # TODO: Simplify
+        order = await asyncio.to_thread(
+            precompute_order,
+            client,
+            ledger_client,
+            market,
+            subaccount,
+            OrderSide.BUY,
+            BUY_PRICE,
+            client_id,
+            0,
+            client.calculate_good_til_block_time(GTBT_DELTA),
+            SIZE,
+            ORDER_FLAGS_LONG_TERM,
+            TIME_IN_FORCE,
+            sequence,
+        )
+        orders = [order]
         logging.info(f"Placing orders {num_blocks_placed}")
-        current_block = client.get_current_block()
+        current_block = await asyncio.to_thread(client.get_current_block)
 
-        await asyncio.create_task(
-            place_orders(
-                ledger_client,
-                current_block,
-                orders,
-                batch_writer,
-            )
+        await place_orders(
+            ledger_client,
+            current_block,
+            orders,
+            batch_writer,
         )
 
         client_id += 1
         num_blocks_placed += 1
+        sequence += 1
 
         # stay under the stateful order rate limit
         await asyncio.sleep(PLACE_INTERVAL)
 
     logging.info("Finished placing orders")
-
-    logging.info("Finished placing orders")
-
 
 
 async def main():
@@ -120,8 +120,10 @@ async def main():
         DATASET_ID, TABLE_ID, WORKER_COUNT, BATCH_SIZE, BATCH_TIMEOUT
     )
     batch_writer_task = asyncio.create_task(batch_writer.batch_writer_loop())
-    await listen_to_block_stream_and_place_orders(batch_writer)
-    await batch_writer_task
+    listen_task = asyncio.create_task(
+        listen_to_block_stream_and_place_orders(batch_writer)
+    )
+    await asyncio.gather(batch_writer_task, listen_task)
 
 
 if __name__ == "__main__":

--- a/place_stateful_orders.py
+++ b/place_stateful_orders.py
@@ -77,9 +77,7 @@ async def listen_to_block_stream_and_place_orders(batch_writer):
     while num_blocks_placed < NUM_BLOCKS:
         # only place one order each time, due to Stateful order rate limit
         logging.info(f"Presigning orders {num_blocks_placed}")
-        # TODO: Simplify
-        order = await asyncio.to_thread(
-            precompute_order,
+        order = precompute_order(
             client,
             ledger_client,
             market,
@@ -93,6 +91,7 @@ async def listen_to_block_stream_and_place_orders(batch_writer):
             ORDER_FLAGS_LONG_TERM,
             TIME_IN_FORCE,
             sequence,
+            account.number
         )
         orders = [order]
         logging.info(f"Placing orders {num_blocks_placed}")

--- a/place_taker_orders.py
+++ b/place_taker_orders.py
@@ -87,6 +87,7 @@ def pre_signing_thread(client, ledger_client, market, subaccount, orders, lock):
                             ORDER_FLAGS_SHORT_TERM,
                             TIME_IN_FORCE,
                             account.sequence,
+                            account.number,
                         )
                     )
                     orders[current_block].append(
@@ -104,6 +105,7 @@ def pre_signing_thread(client, ledger_client, market, subaccount, orders, lock):
                             ORDER_FLAGS_SHORT_TERM,
                             TIME_IN_FORCE,
                             account.sequence,
+                            account.number,
                         )
                     )
                 client_id += NUM_ORDERS_PER_SIDE_EACH_BLOCK * 2

--- a/run_all_scripts.py
+++ b/run_all_scripts.py
@@ -166,17 +166,17 @@ def main():
             if process.poll() is not None:
                 logging.info(f"{script_name} ({config}) has stopped, restarting...")
                 processes[config] = start_script(script_name, args)
-
-            processes[config] = check_and_restart_script(
-                process,
-                config,
-                script_name,
-                table_id,
-                timestamp_column,
-                filter_condition,
-                args,
-                info["time_threshold"],
-            )
+            else:
+                processes[config] = check_and_restart_script(
+                    process,
+                    config,
+                    script_name,
+                    table_id,
+                    timestamp_column,
+                    filter_condition,
+                    args,
+                    info["time_threshold"],
+                )
 
         time.sleep(CHECK_INTERVAL)
 

--- a/run_all_scripts.py
+++ b/run_all_scripts.py
@@ -12,6 +12,7 @@ import sys
 import time
 from datetime import datetime, timedelta, timezone
 from logging.handlers import RotatingFileHandler
+from typing import Dict
 
 from google.cloud import bigquery
 
@@ -94,6 +95,24 @@ def start_script(script_name, args):
     return subprocess.Popen(["python", script_name] + args)
 
 
+def force_kill_process(process: subprocess.Popen, pname: str):
+    # Try to terminate the process
+    logging.info(f"Terminating process {pname}...")
+    process.terminate()
+
+    # Wait for a few seconds to give the process time to terminate
+    time.sleep(3)
+
+    # Check if the process has terminated
+    if process.poll() is None:
+        # Process is still alive, so forcefully kill it
+        logging.info(f"Forcefully killing process {pname}...")
+        process.kill()
+
+    process.wait()
+    logging.info(f"Process {pname} has finished.")
+
+
 def check_and_restart_script(
     process,
     config_name,
@@ -128,15 +147,14 @@ def check_and_restart_script(
         should_restart = True
 
     if should_restart:
-        process.kill()
-        process.wait()
+        force_kill_process(process, script_name)
         return start_script(script_name, args)
     else:
         return process
 
 
 def main():
-    processes = {
+    processes: Dict[str, subprocess.Popen] = {
         config: start_script(info["script_name"], info["args"])
         for config, info in SCRIPT_CONFIGS.items()
     }
@@ -144,9 +162,8 @@ def main():
     # Gracefully handle Ctrl+C
     def signal_handler(sig, frame):
         logging.info("Received termination signal, shutting down...")
-        for process in processes.values():
-            process.terminate()
-            process.wait()
+        for pname, p in processes.items():
+            force_kill_process(p, pname)
         sys.exit(0)
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)


### PR DESCRIPTION
Changes:
1. Update the batch writer to fall back to sideloading rows into BigQuery via GCS if it sees a 413 payload too large error -- this was necessary because sometimes a row is under the limit, but a batch is above.
2. Fix a bug in the run_all_scripts.py scheduler that would sometimes double run tasks (in practice leading to many place_stateful_orders.py scripts running at once)
3. Fix bugs in place_orders.py and place_stateful_orders.py that used blocking code in async functions.
4. Update order signing to not need to query the chain (faster, more reliable).
5. Subscribe to 1000 clob pair ids so we don't need to bump the number manually when new markets are listed - until there are 1000 markets :) 